### PR TITLE
Create Category model

### DIFF
--- a/app/models/restaurant_category.rb
+++ b/app/models/restaurant_category.rb
@@ -1,0 +1,2 @@
+class RestaurantCategory < ActiveRecord::Base
+end

--- a/app/models/restaurant_category.rb
+++ b/app/models/restaurant_category.rb
@@ -1,2 +1,5 @@
 class RestaurantCategory < ActiveRecord::Base
+
+  validates_presence_of :title
+  validates_uniqueness_of :title
 end

--- a/db/migrate/20160618054757_create_restaurant_categories.rb
+++ b/db/migrate/20160618054757_create_restaurant_categories.rb
@@ -1,0 +1,7 @@
+class CreateRestaurantCategories < ActiveRecord::Migration
+  def change
+    create_table :restaurant_categories do |t|
+      t.string :title
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20160618054757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "restaurant_categories", force: :cascade do |t|
+    t.string "title"
+  end
 
 end

--- a/db/seed_methods.rb
+++ b/db/seed_methods.rb
@@ -1,0 +1,5 @@
+def create_restaurant_categories(rest_cats)
+  rest_cats.each do |category|
+    RestaurantCategory.create(title: category)
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,5 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
-#
-# Examples:
-#
-#   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
-#   Mayor.create(name: 'Emanuel', city: cities.first)
+require_relative 'seed_methods'
+
+create_restaurant_categories(%w(Thai Italian Steakhouse))
+
+

--- a/spec/factories/restaurant_categories.rb
+++ b/spec/factories/restaurant_categories.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :restaurant_category do
+    title 'Test Category'
+  end
+end

--- a/spec/models/restaurant_category_spec.rb
+++ b/spec/models/restaurant_category_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe RestaurantCategory, type: :model do
+
+  describe 'Fixtures' do
+    it 'should have valid Factory' do
+      expect(FactoryGirl.create(:restaurant_category)).to be_valid
+    end
+  end
+
+  describe 'DB table' do
+    it { is_expected.to have_db_column :id }
+    it { is_expected.to have_db_column :title }
+  end
+
+end

--- a/spec/models/restaurant_category_spec.rb
+++ b/spec/models/restaurant_category_spec.rb
@@ -13,4 +13,10 @@ RSpec.describe RestaurantCategory, type: :model do
     it { is_expected.to have_db_column :title }
   end
 
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_uniqueness_of(:title) }
+
+  end
+
 end


### PR DESCRIPTION
PT Story https://www.pivotaltracker.com/story/show/121652187
- Creates a Category Model named `RestaurantCategory`
- Adds conditions for presence and uniqueness on `title`
- Adds seeded Categories. Used with: 

```
  rake db:seed
```
- Does NOT add a relationship to Restaurant model. Postponed to https://www.pivotaltracker.com/story/show/121652115
