### PR TITLE
Add lat and lang to Restaurant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'faker'
 gem 'haml-rails' # Template engine
 gem 'devise'
 gem 'cancancan'
+gem 'geocoder'
 # gem 'foundation-rails'
 
 group :development, :test do
@@ -29,8 +30,4 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
   gem 'spring'
-end
-
-group :test do
-  gem 'database_cleaner'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,7 @@ GEM
       railties (>= 3.0.0)
     faker (1.6.3)
       i18n (~> 0.5)
+    geocoder (1.3.6)
     gherkin (4.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -270,6 +271,7 @@ DEPENDENCIES
   devise
   factory_girl_rails
   faker
+  geocoder
   haml-rails
   jquery-rails
   launchy
@@ -286,3 +288,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.12.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,6 +288,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.12.5

--- a/app/models/restaurant.rb
+++ b/app/models/restaurant.rb
@@ -6,4 +6,11 @@ class Restaurant < ActiveRecord::Base
   validates_uniqueness_of :name
 
   validates_presence_of :restaurant_category
+
+  geocoded_by :full_street_address
+  after_validation :geocode
+
+  def full_street_address
+    self.address
+  end
 end

--- a/db/migrate/20160623113405_add_lat_and_lon_to_restaurant.rb
+++ b/db/migrate/20160623113405_add_lat_and_lon_to_restaurant.rb
@@ -1,6 +1,6 @@
 class AddLatAndLonToRestaurant < ActiveRecord::Migration
   def change
-    add_column :restaurants, :lat, :float
-    add_column :restaurants, :lon, :float
+    add_column :restaurants, :latitude, :float
+    add_column :restaurants, :longitude, :float
   end
 end

--- a/db/migrate/20160623113405_add_lat_and_lon_to_restaurant.rb
+++ b/db/migrate/20160623113405_add_lat_and_lon_to_restaurant.rb
@@ -1,0 +1,6 @@
+class AddLatAndLonToRestaurant < ActiveRecord::Migration
+  def change
+    add_column :restaurants, :lat, :float
+    add_column :restaurants, :lon, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160621084608) do
+ActiveRecord::Schema.define(version: 20160623113405) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,8 @@ ActiveRecord::Schema.define(version: 20160621084608) do
     t.datetime "updated_at",                            null: false
     t.text     "description"
     t.integer  "user_id"
+    t.float    "lat"
+    t.float    "lon"
   end
 
   add_index "restaurants", ["restaurant_category_id"], name: "index_restaurants_on_restaurant_category_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 20160623113405) do
     t.datetime "updated_at",                            null: false
     t.text     "description"
     t.integer  "user_id"
-    t.float    "lat"
-    t.float    "lon"
+    t.float    "latitude"
+    t.float    "longitude"
   end
 
   add_index "restaurants", ["restaurant_category_id"], name: "index_restaurants_on_restaurant_category_id", using: :btree

--- a/db/seed_methods.rb
+++ b/db/seed_methods.rb
@@ -12,10 +12,14 @@ def create_restaurant(args = {})
   description = args[:description] || Faker::Lorem.paragraph(2)
   address = args[:address] || [Faker::Address.street_address, Faker::Address.postcode, Faker::Address.city].join(', ')
   phone_number = args[:phone] || Faker::PhoneNumber.cell_phone
-
-  Restaurant.create(name: name,
+  lat = rand(59.0000001..59.4000009).round(7)
+  lon = rand(18.0000001..18.4000009).round(7)
+  rest = Restaurant.new(name: name,
                     description: description,
                     address: address,
                     phone: phone_number,
-                    restaurant_category: cat)
+                    restaurant_category: cat,
+                    latitude: lat,
+                    longitude: lon)
+  rest.save(validate: false)
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to have_db_column :address }
     it { is_expected.to have_db_column :phone }
     it { is_expected.to have_db_column :org_number }
+    it { is_expected.to have_db_column :lon }
+    it { is_expected.to have_db_column :lat }
   end
 
   describe 'Relationships' do
@@ -26,4 +28,5 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to validate_uniqueness_of(:name) }
     it { is_expected.to validate_presence_of(:restaurant_category) }
   end
+
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -29,4 +29,16 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to validate_presence_of(:restaurant_category) }
   end
 
+  describe '#full_street_address' do
+    subject do
+      FactoryGirl.create(:restaurant,
+      name: 'Operakällaren',
+      address: 'Karl XII:s torg, 111 86 Stockholm' )
+    end
+
+    it 'returns full address' do
+      expect(subject.full_street_address).to eq 'Karl XII:s torg, 111 86 Stockholm'
+    end
+  end
+
 end

--- a/spec/models/restaurant_spec.rb
+++ b/spec/models/restaurant_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Restaurant, type: :model do
     it { is_expected.to have_db_column :address }
     it { is_expected.to have_db_column :phone }
     it { is_expected.to have_db_column :org_number }
-    it { is_expected.to have_db_column :lon }
-    it { is_expected.to have_db_column :lat }
+    it { is_expected.to have_db_column :longitude }
+    it { is_expected.to have_db_column :latitude }
   end
 
   describe 'Relationships' do
@@ -38,6 +38,14 @@ RSpec.describe Restaurant, type: :model do
 
     it 'returns full address' do
       expect(subject.full_street_address).to eq 'Karl XII:s torg, 111 86 Stockholm'
+    end
+
+    it 'can has a latitude' do
+      expect(subject.latitude).to eq 59.3303544
+    end
+
+    it 'can has a longitude' do
+      expect(subject.longitude).to eq 18.0720205
     end
   end
 


### PR DESCRIPTION
PT Story https://www.pivotaltracker.com/story/show/122057831
- adds attributes (latitude & longitude)
- adds geocoder gem
- geocodes restaurant by full address
- updates method to seed db with Restaurants
- Note: removes a redundant gem in Gemfile
